### PR TITLE
Fix of blank screen on slow internet

### DIFF
--- a/sdk/src/main/java/io/verloop/sdk/ui/VerloopFragment.kt
+++ b/sdk/src/main/java/io/verloop/sdk/ui/VerloopFragment.kt
@@ -80,7 +80,7 @@ class VerloopFragment : Fragment() {
                 return true
             }
 
-            override fun onPageFinished(view: WebView, url: String) {
+            override fun onPageCommitVisible(view: WebView, url: String) {
                 super.onPageFinished(view, url)
                 startRoom()
             }

--- a/sdk/src/main/java/io/verloop/sdk/ui/VerloopFragment.kt
+++ b/sdk/src/main/java/io/verloop/sdk/ui/VerloopFragment.kt
@@ -81,7 +81,7 @@ class VerloopFragment : Fragment() {
             }
 
             override fun onPageCommitVisible(view: WebView, url: String) {
-                super.onPageFinished(view, url)
+                super.onPageCommitVisible(view, url)
                 startRoom()
             }
         }


### PR DESCRIPTION
updating onPageFinished with onPageCommitVisible as some of the js files were not yet loaded before it started page rendering on slow internet