### PR TITLE
Fixing the Android 13 isInterface() Null Pointer Exception Crash

### DIFF
--- a/sdk/src/main/java/io/verloop/sdk/ui/VerloopActivity.kt
+++ b/sdk/src/main/java/io/verloop/sdk/ui/VerloopActivity.kt
@@ -107,11 +107,8 @@ class VerloopActivity : AppCompatActivity() {
 
     @Suppress("DEPRECATION")
     private fun getConfig(): VerloopConfig? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra("config", VerloopConfig::class.java)
-        } else {
-            intent.getParcelableExtra("config")
-        }
+        // Needs to replaced with IntentCompat.getParcelableExtra(intent, "config", VerloopConfig::class.java) after upgrading API 34
+        return intent.getParcelableExtra("config")
     }
 
     override fun onResume() {


### PR DESCRIPTION
- Removed the getParcelableExtra check for Android 13 to avoid NPE crash