### PR TITLE
Android 14 Upgarde & IntentCompat for Android 13 NPE Crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 33
     defaultConfig {
+        compileSdk 34
         applicationId "io.verloop.demo"
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         multiDexEnabled = true
@@ -19,9 +19,10 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
+    namespace 'io.verloop'
 }
 
 dependencies {
@@ -44,7 +45,7 @@ dependencies {
 
     androidTestImplementation "androidx.work:work-testing:2.7.1"
 
-    implementation 'com.google.firebase:firebase-messaging-ktx:23.0.5'
+    implementation 'com.google.firebase:firebase-messaging-ktx:23.0.6'
     implementation platform('com.google.firebase:firebase-bom:29.0.3')
     implementation 'com.google.firebase:firebase-analytics-ktx'
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,10 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class retrofit2.** { *; }
+-keepattributes *Annotation*
+-keep class com.squareup.okhttp.** { *; }
+-keep interface com.squareup.okhttp.** { *; }
+-keep class okhttp3.** { *; }
+-keep interface okhttp3.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-
-    package="io.verloop">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.8.0'
     ext.mockito_version = '3.6.28'
 
     repositories {
@@ -12,8 +12,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
-        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath 'com.google.gms:google-services:4.4.1'
 //        classpath 'com.kezong:fat-aar:1.2.15'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 authToken=jp_2a49qaprgeac1ag5o3aam8rust
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false
+#android.enableR8.fullMode=false #Enable this if R8 causes proguard related issues

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jan 16 11:00:42 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'org.jetbrains.kotlin.android.extensions'
+apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 33
 
     defaultConfig {
+        compileSdk 34
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 34
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         multiDexEnabled true
     }
@@ -20,13 +20,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
-    androidExtensions {
-        experimental = true
-    }
+    namespace 'io.verloop.sdk'
 }
 
 buildscript {
@@ -50,7 +48,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockito_version"
     androidTestImplementation "org.mockito:mockito-android:$mockito_version"
 
-    implementation "androidx.core:core-ktx:1.8.0"
+    implementation "androidx.core:core-ktx:1.10.0"
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.4.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
@@ -87,7 +85,7 @@ group = publishedGroupId
 version = libraryVersion
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier.set("sources")
     from android.sourceSets.main.java.srcDirs
 }
 
@@ -98,7 +96,7 @@ task javadoc(type: Javadoc) {
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set("javadoc")
     from javadoc.destinationDir
 }
 

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.verloop.sdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/sdk/src/main/java/io/verloop/sdk/VerloopNotification.kt
+++ b/sdk/src/main/java/io/verloop/sdk/VerloopNotification.kt
@@ -7,7 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
-import android.os.Build.VERSION_CODES.S
+import android.os.Build.VERSION_CODES.M
 import android.util.Log
 import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationCompat
@@ -81,8 +81,8 @@ object VerloopNotification {
             dataPayload.let { notificationIntent?.putExtra("verloop", it.toString()) }
 
             notificationIntent?.flags = (Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            val flag = if (Build.VERSION.SDK_INT >= S)
-                (PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+            val flag = if (Build.VERSION.SDK_INT >= M)
+                (PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
             else
                 PendingIntent.FLAG_UPDATE_CURRENT
             val contentIntent = PendingIntent.getActivity(

--- a/sdk/src/main/java/io/verloop/sdk/ui/VerloopActivity.kt
+++ b/sdk/src/main/java/io/verloop/sdk/ui/VerloopActivity.kt
@@ -2,7 +2,11 @@ package io.verloop.sdk.ui
 
 import android.Manifest
 import android.content.Intent
-import android.graphics.*
+import android.graphics.BitmapFactory
+import android.graphics.BlendMode
+import android.graphics.BlendModeColorFilter
+import android.graphics.Color
+import android.graphics.PorterDuff
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -17,6 +21,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import androidx.core.content.IntentCompat
 import androidx.core.graphics.BlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat
 import androidx.lifecycle.ViewModelProvider
@@ -105,13 +110,8 @@ class VerloopActivity : AppCompatActivity() {
         else "https://${this.config!!.clientId}.verloop.io"
     }
 
-    @Suppress("DEPRECATION")
     private fun getConfig(): VerloopConfig? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra("config", VerloopConfig::class.java)
-        } else {
-            intent.getParcelableExtra("config")
-        }
+        return IntentCompat.getParcelableExtra(intent, "config", VerloopConfig::class.java)
     }
 
     override fun onResume() {

--- a/sdk/src/main/java/io/verloop/sdk/ui/VerloopFragment.kt
+++ b/sdk/src/main/java/io/verloop/sdk/ui/VerloopFragment.kt
@@ -22,6 +22,7 @@ import android.widget.ProgressBar
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.core.os.BundleCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import io.verloop.sdk.Constants
@@ -72,12 +73,7 @@ class VerloopFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        config = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            arguments?.getParcelable("config", VerloopConfig::class.java)
-        } else {
-            @Suppress("DEPRECATION") arguments?.getParcelable("config")
-        }
-
+        config = arguments?.let { BundleCompat.getParcelable(it, "config",  VerloopConfig::class.java) }
         configKey = arguments?.getString("configKey")
 
         if (config != null) {


### PR DESCRIPTION
- Removed the getParcelableExtra and replaced with Intent Compat check for Android 13 to avoid NPE crash
- Android SDK 34 Added
- Upgraded core-ktx to 1.10.0 to enable IntentCompat method
- Upgraded kotlin to 1.8.0 to support core-ktx:1.1.0.0
- upgraded AGP to 8.2 to support API 34
- Upgraded Firebase to 23.0.6 to avoid build error ref: https://github.com/firebase/firebase-android-sdk/issues/3740
- Upgraded Java to 17 to support Kotlin 1.8.0
- Added proguard rules to resolve retrofit proguard error