### PR TITLE
fix: unsafe WebView JS parameter handling

### DIFF
--- a/app/src/main/java/io/verloop/TestActivity.kt
+++ b/app/src/main/java/io/verloop/TestActivity.kt
@@ -17,6 +17,8 @@ import io.verloop.sdk.utils.NetworkUtils
 import org.json.JSONException
 import org.json.JSONObject
 import android.net.Uri
+import android.webkit.WebView
+
 class TestActivity : AppCompatActivity() {
 
     private val TAG: String = "TestActivity"
@@ -28,6 +30,7 @@ class TestActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_test)
+        WebView.setWebContentsDebuggingEnabled(true);
 
         // Use either header config or overrideHeaderLayout
         headerConfig = HeaderConfig.Builder()

--- a/app/src/main/java/io/verloop/TestActivity.kt
+++ b/app/src/main/java/io/verloop/TestActivity.kt
@@ -17,7 +17,6 @@ import io.verloop.sdk.utils.NetworkUtils
 import org.json.JSONException
 import org.json.JSONObject
 import android.net.Uri
-import android.webkit.WebView
 
 class TestActivity : AppCompatActivity() {
 

--- a/app/src/main/java/io/verloop/TestActivity.kt
+++ b/app/src/main/java/io/verloop/TestActivity.kt
@@ -30,7 +30,6 @@ class TestActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_test)
-        WebView.setWebContentsDebuggingEnabled(true);
 
         // Use either header config or overrideHeaderLayout
         headerConfig = HeaderConfig.Builder()

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         <activity
             android:name=".ui.VerloopActivity"
             android:alwaysRetainTaskState="true"
-            android:exported="true"
+            android:exported="false"
             android:fitsSystemWindows="true"
             android:windowSoftInputMode="adjustResize"
             android:launchMode="singleTop"

--- a/sdk/src/main/java/io/verloop/sdk/ui/VerloopFragment.kt
+++ b/sdk/src/main/java/io/verloop/sdk/ui/VerloopFragment.kt
@@ -391,10 +391,9 @@ class VerloopFragment : Fragment() {
             if (!it.userEmail.isNullOrEmpty()) userParamsObject.put("email", it.userEmail)
             if (!it.userName.isNullOrEmpty()) userParamsObject.put("name", it.userName)
             if (!it.userPhone.isNullOrEmpty()) userParamsObject.put("phone", it.userPhone)
-
             if (userParamsObject.length() > 0) {
                 logEvent(LogLevel.DEBUG, Constants.JS_CALL_SET_USER_PARAMS, userParamsObject)
-                callJavaScript("VerloopLivechat.setUserParams(${userParamsObject});")
+                callJavaScript("VerloopLivechat.setUserParams(${userParamsObject.toString()});")
             }
             if (!it.userId.isNullOrEmpty()) {
                 logEvent(
@@ -402,21 +401,21 @@ class VerloopFragment : Fragment() {
                     Constants.JS_CALL_SET_USER_ID,
                     JSONObject().put("userId", it.userId)
                 )
-                callJavaScript("VerloopLivechat.setUserId(\"${it.userId}\");")
+                callJavaScript("VerloopLivechat.setUserId(${JSONObject.quote(it.userId)});")
             }
             if (!it.department.isNullOrEmpty()) {
                 logEvent(
                     LogLevel.DEBUG, Constants.JS_CALL_SET_DEPARTMENT,
                     JSONObject().put("department", it.department)
                 )
-                callJavaScript("VerloopLivechat.setDepartment(\"${it.department}\");")
+                callJavaScript("VerloopLivechat.setDepartment(${JSONObject.quote(it.department)});")
             }
             if (!it.recipeId.isNullOrEmpty()) {
                 logEvent(
                     LogLevel.DEBUG, Constants.JS_CALL_SET_RECIPE,
                     JSONObject().put("recipeId", it.recipeId)
                 )
-                callJavaScript("VerloopLivechat.setRecipe(\"${it.recipeId}\");")
+                callJavaScript("VerloopLivechat.setRecipe(${JSONObject.quote(it.recipeId)});")
             }
 
             // Custom Fields
@@ -435,7 +434,7 @@ class VerloopFragment : Fragment() {
                         Constants.JS_CALL_SET_CUSTOM_FIELD,
                         params
                     )
-                    callJavaScript("VerloopLivechat.setCustomField(\"${field.key}\", \"${field.value}\", ${scopeObject});")
+                    callJavaScript("VerloopLivechat.setCustomField(${JSONObject.quote(field.key)},${JSONObject.quote(field.value)}, ${scopeObject});")
                 }
             }
 
@@ -444,7 +443,7 @@ class VerloopFragment : Fragment() {
                     LogLevel.DEBUG, Constants.JS_CALL_SHOW_DOWNLOAD_BUTTON,
                     JSONObject().put("showDownloadButton", it.allowFileDownload)
                 )
-                callJavaScript("VerloopLivechat.showDownloadButton(\"${it.allowFileDownload}\");")
+                callJavaScript("VerloopLivechat.showDownloadButton(${it.allowFileDownload});")
             }
         }
         logEvent(LogLevel.DEBUG, Constants.JS_CALL_WIDGET_OPENED, null)


### PR DESCRIPTION
- Escaped all dynamic string values using JSONObject.quote()
- Passed boolean parameters as native booleans instead of strings
- Added webview debug in sample app for inspecting webview network logs